### PR TITLE
Adding 3 more rules

### DIFF
--- a/exec_dir/Makefile
+++ b/exec_dir/Makefile
@@ -23,6 +23,9 @@ naming:
 	python3 ../py_src/pyslint.py -t ../sv_tests/test_sv_naming_20_p.sv >> pyslint.log
 	python3 ../py_src/pyslint.py -t ../sv_tests/test_sv_naming_21_f.sv >> pyslint.log
 	python3 ../py_src/pyslint.py -t ../sv_tests/test_sv_naming_22_f.sv >> pyslint.log
+	python3 ../py_src/pyslint.py -t ../sv_tests/test_sv_naming_23_f.sv >> pyslint.log
+	python3 ../py_src/pyslint.py -t ../sv_tests/test_sv_naming_24_f.sv >> pyslint.log
+	python3 ../py_src/pyslint.py -t ../sv_tests/test_sv_naming_25_f.sv >> pyslint.log
 
 	cat pyslint.log
 

--- a/exec_dir/pyslint.log
+++ b/exec_dir/pyslint.log
@@ -1,7 +1,37 @@
+Following line has a trailing whitespace
+Line 2: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
+PySlint: Violation: [FILE_NAME_CHECK_MODULE]: Improper File name :../sv_tests/test_sv_naming_01_p.sv Expected File name af_ af_sv_if.sv
+Following line has a trailing whitespace
+Line 2: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 PySlint: Violation: [NAME_INTF_SUFFIX]: Improper naming of identifier:  af_sv_intf_bad: expected suffix: _if
+PySlint: Violation: [FILE_NAME_CHECK_MODULE]: Improper File name :../sv_tests/test_sv_naming_02_f.sv Expected File name af_ af_sv_intf_bad.sv
+Following line has a trailing whitespace
+Line 2: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 PySlint: Violation: [NAME_CLASS_SUFFIX]: Improper naming of identifier:  af_bad_class_name: expected suffix: _c
+PySlint: Violation: [FILE_NAME_CHECK_CLASS]: Improper File name : ../sv_tests/test_sv_naming_03_p.sv Expected File name af_ af_bad_class_name.sv
+Following line has a trailing whitespace
+Line 2: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
+PySlint: Violation: [FILE_NAME_CHECK_CLASS]: Improper File name : ../sv_tests/test_sv_naming_04_f.sv Expected File name af_ af_good_c.sv
+Following line has a trailing whitespace
+Line 2: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
+PySlint: Violation: [FILE_NAME_CHECK_CLASS]: Improper File name : ../sv_tests/test_sv_naming_05_p.sv Expected File name af_ cg_wrap_c.sv
+Following line has a trailing whitespace
+Line 2: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 PySlint: Violation: [NAME_CG_PREFIX]: Improper naming of identifier: bad_group_name: expected prefix: cg_
+PySlint: Violation: [FILE_NAME_CHECK_CLASS]: Improper File name : ../sv_tests/test_sv_naming_06_f.sv Expected File name af_ cg_wrap_c.sv
+Following line has a trailing whitespace
+Line 2: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
+PySlint: Violation: [FILE_NAME_CHECK_MODULE]: Improper File name :../sv_tests/test_sv_naming_07_p.sv Expected File name af_ cg_wrap_m.sv
+Following line has a trailing whitespace
+Line 2: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
+PySlint: Violation: [FILE_NAME_CHECK_MODULE]: Improper File name :../sv_tests/test_sv_naming_08_f.sv Expected File name af_ cg_wrap_m.sv
 PySlint: Violation: [NAME_CG_PREFIX]: Improper naming of identifier: bad_group_name: expected prefix: cg_
+Following line has a trailing whitespace
+Line 2: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
+PySlint: Violation: [FILE_NAME_CHECK_MODULE]: Improper File name :../sv_tests/test_sv_naming_09_p.sv Expected File name af_ sva_m.sv
+Following line has a trailing whitespace
+Line 2: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
+PySlint: Violation: [FILE_NAME_CHECK_MODULE]: Improper File name :../sv_tests/test_sv_naming_10_f.sv Expected File name af_ sva_m.sv
 PySlint: Violation: [SVA_MISSING_LABEL]: Unnamed assertion - use a meaningful label: 
   // BAD - unnamed SVA
   assert property (@(posedge clk) var1)
@@ -14,10 +44,19 @@ PySlint: Violation: [SVA_MISSING_LABEL]: Unnamed assumption - use a meaningful l
   // BAD - unnamed SVA
   assert property (@(posedge clk) var1)
     else $error ("Bad style - unnamed SVA");
+Following line has a trailing whitespace
+Line 2: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
+PySlint: Violation: [FILE_NAME_CHECK_MODULE]: Improper File name :../sv_tests/test_sv_naming_11_f.sv Expected File name af_ sva_m.sv
 PySlint: Violation: [NAME_AST_PREFIX]: Improper naming of assert directive: bad_sva_label: expected prefix: a_
+Following line has a trailing whitespace
+Line 2: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
+PySlint: Violation: [FILE_NAME_CHECK_MODULE]: Improper File name :../sv_tests/test_sv_naming_12_f.sv Expected File name af_ sva_m.sv
 PySlint: Violation: [SVA_MISSING_FAIL_AB]: Missing FAIL Action block - use $error/`uvm_error: 
   // BAD - missing FAIL action block in SVA
   a_var1 : assert property (@(posedge clk) var1);
+Following line has a trailing whitespace
+Line 2: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
+PySlint: Violation: [FILE_NAME_CHECK_MODULE]: Improper File name :../sv_tests/test_sv_naming_13_f.sv Expected File name af_ sva_m.sv
 PySlint: Violation: [SVA_NO_PASS_AB]: Avoid using PASS Action block - likely to cause too many vacuous prints: 
   // BAD - avoid using PASS action block in SVA
   // It usually leads to too many vacuous prints
@@ -26,10 +65,50 @@ PySlint: Violation: [SVA_NO_PASS_AB]: Avoid using PASS Action block - likely to 
       $info ("Pass Action Block");
     end : pass_ab
    else $error ("Fail AB");
+Following line has a trailing whitespace
+Line 2: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
+PySlint: Violation: [FILE_NAME_CHECK_MODULE]: Improper File name :../sv_tests/test_sv_naming_14_p.sv Expected File name af_ sva_m.sv
+Following line has a trailing whitespace
+Line 2: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
+PySlint: Violation: [FILE_NAME_CHECK_MODULE]: Improper File name :../sv_tests/test_sv_naming_15_f.sv Expected File name af_ sva_m.sv
 PySlint: Violation: [NAME_PROP_PREFIX]: Improper naming of property: bad_name: expected prefix: p_
+Following line has a trailing whitespace
+Line 2: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
+Following line has a trailing whitespace
+Line 16:   endproperty
+PySlint: Violation: [FILE_NAME_CHECK_MODULE]: Improper File name :../sv_tests/test_sv_naming_16_f.sv Expected File name af_ sva_m.sv
 PySlint: Violation: [SVA_MISSING_ENDLABEL]: Missing End Label for property: p_good_name
+Following line has a trailing whitespace
+Line 2: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
+PySlint: Violation: [FILE_NAME_CHECK_MODULE]: Improper File name :../sv_tests/test_sv_naming_17_f.sv Expected File name af_ sva_m.sv
 PySlint: Violation: [NAME_PROP_PREFIX]: Improper naming of property: bad_name: expected prefix: p_
+Following line has a trailing whitespace
+Line 2: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
+PySlint: Violation: [FILE_NAME_CHECK_MODULE]: Improper File name :../sv_tests/test_sv_naming_18_f.sv Expected File name af_ sva_m.sv
 PySlint: Violation: [NAME_ASM_PREFIX]: Improper naming of assume directive: wrong_label: expected prefix: m_
+Following line has a trailing whitespace
+Line 2: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
+PySlint: Violation: [FILE_NAME_CHECK_MODULE]: Improper File name :../sv_tests/test_sv_naming_19_f.sv Expected File name af_ sva_m.sv
 PySlint: Violation: [NAME_COV_PREFIX]: Improper naming of cover directive: wrong_label: expected prefix: c_
+Following line has a trailing whitespace
+Line 3: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
+PySlint: Violation: [FILE_NAME_CHECK_CLASS]: Improper File name : ../sv_tests/test_sv_naming_20_p.sv Expected File name af_ ex_c.sv
+Following line has a trailing whitespace
+Line 3: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 PySlint: Violation: [CL_METHOD_NOT_EXTERN]: method is not declared extern:  should_have_been_extern
+PySlint: Violation: [FILE_NAME_CHECK_CLASS]: Improper File name : ../sv_tests/test_sv_naming_21_f.sv Expected File name af_ ex_c.sv
+Following line has a trailing whitespace
+Line 3: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
+Following line has a trailing whitespace
+Line 12: endclass
 PySlint: Violation: [CL_MISSING_ENDLABEL]: Missing End Label for class: ex_c
+PySlint: Violation: [FILE_NAME_CHECK_CLASS]: Improper File name : ../sv_tests/test_sv_naming_22_f.sv Expected File name af_ ex_c.sv
+PySlint: Violation: [FILE_NAME_CHECK_MODULE]: Improper File name :../sv_tests/test_sv_naming_23_f.sv Expected File name af_ memory.sv
+Following line has a trailing whitespace
+Line 5: endclass :add
+PySlint: Violation: [NAME_CLASS_SUFFIX]: Improper naming of identifier:  add: expected suffix: _c
+PySlint: Violation: [FILE_NAME_CHECK_CLASS]: Improper File name : ../sv_tests/test_sv_naming_24_f.sv Expected File name af_ add.sv
+Following line has a trailing whitespace
+Line 3:   bit line_with_trailing_space;
+PySlint: Violation: [NAME_CLASS_SUFFIX]: Improper naming of identifier:  trailing_whitespace: expected suffix: _c
+PySlint: Violation: [FILE_NAME_CHECK_CLASS]: Improper File name : ../sv_tests/test_sv_naming_25_f.sv Expected File name af_ trailing_whitespace.sv

--- a/exec_dir/pyslint.log
+++ b/exec_dir/pyslint.log
@@ -1,36 +1,16 @@
-Following line has a trailing whitespace
-Line 2: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 PySlint: Violation: [FILE_NAME_CHECK_MODULE]: Improper File name :../sv_tests/test_sv_naming_01_p.sv Expected File name af_ af_sv_if.sv
-Following line has a trailing whitespace
-Line 2: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 PySlint: Violation: [NAME_INTF_SUFFIX]: Improper naming of identifier:  af_sv_intf_bad: expected suffix: _if
 PySlint: Violation: [FILE_NAME_CHECK_MODULE]: Improper File name :../sv_tests/test_sv_naming_02_f.sv Expected File name af_ af_sv_intf_bad.sv
-Following line has a trailing whitespace
-Line 2: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 PySlint: Violation: [NAME_CLASS_SUFFIX]: Improper naming of identifier:  af_bad_class_name: expected suffix: _c
 PySlint: Violation: [FILE_NAME_CHECK_CLASS]: Improper File name : ../sv_tests/test_sv_naming_03_p.sv Expected File name af_ af_bad_class_name.sv
-Following line has a trailing whitespace
-Line 2: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 PySlint: Violation: [FILE_NAME_CHECK_CLASS]: Improper File name : ../sv_tests/test_sv_naming_04_f.sv Expected File name af_ af_good_c.sv
-Following line has a trailing whitespace
-Line 2: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 PySlint: Violation: [FILE_NAME_CHECK_CLASS]: Improper File name : ../sv_tests/test_sv_naming_05_p.sv Expected File name af_ cg_wrap_c.sv
-Following line has a trailing whitespace
-Line 2: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 PySlint: Violation: [NAME_CG_PREFIX]: Improper naming of identifier: bad_group_name: expected prefix: cg_
 PySlint: Violation: [FILE_NAME_CHECK_CLASS]: Improper File name : ../sv_tests/test_sv_naming_06_f.sv Expected File name af_ cg_wrap_c.sv
-Following line has a trailing whitespace
-Line 2: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 PySlint: Violation: [FILE_NAME_CHECK_MODULE]: Improper File name :../sv_tests/test_sv_naming_07_p.sv Expected File name af_ cg_wrap_m.sv
-Following line has a trailing whitespace
-Line 2: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 PySlint: Violation: [FILE_NAME_CHECK_MODULE]: Improper File name :../sv_tests/test_sv_naming_08_f.sv Expected File name af_ cg_wrap_m.sv
 PySlint: Violation: [NAME_CG_PREFIX]: Improper naming of identifier: bad_group_name: expected prefix: cg_
-Following line has a trailing whitespace
-Line 2: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 PySlint: Violation: [FILE_NAME_CHECK_MODULE]: Improper File name :../sv_tests/test_sv_naming_09_p.sv Expected File name af_ sva_m.sv
-Following line has a trailing whitespace
-Line 2: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 PySlint: Violation: [FILE_NAME_CHECK_MODULE]: Improper File name :../sv_tests/test_sv_naming_10_f.sv Expected File name af_ sva_m.sv
 PySlint: Violation: [SVA_MISSING_LABEL]: Unnamed assertion - use a meaningful label: 
   // BAD - unnamed SVA
@@ -44,18 +24,12 @@ PySlint: Violation: [SVA_MISSING_LABEL]: Unnamed assumption - use a meaningful l
   // BAD - unnamed SVA
   assert property (@(posedge clk) var1)
     else $error ("Bad style - unnamed SVA");
-Following line has a trailing whitespace
-Line 2: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 PySlint: Violation: [FILE_NAME_CHECK_MODULE]: Improper File name :../sv_tests/test_sv_naming_11_f.sv Expected File name af_ sva_m.sv
 PySlint: Violation: [NAME_AST_PREFIX]: Improper naming of assert directive: bad_sva_label: expected prefix: a_
-Following line has a trailing whitespace
-Line 2: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 PySlint: Violation: [FILE_NAME_CHECK_MODULE]: Improper File name :../sv_tests/test_sv_naming_12_f.sv Expected File name af_ sva_m.sv
 PySlint: Violation: [SVA_MISSING_FAIL_AB]: Missing FAIL Action block - use $error/`uvm_error: 
   // BAD - missing FAIL action block in SVA
   a_var1 : assert property (@(posedge clk) var1);
-Following line has a trailing whitespace
-Line 2: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 PySlint: Violation: [FILE_NAME_CHECK_MODULE]: Improper File name :../sv_tests/test_sv_naming_13_f.sv Expected File name af_ sva_m.sv
 PySlint: Violation: [SVA_NO_PASS_AB]: Avoid using PASS Action block - likely to cause too many vacuous prints: 
   // BAD - avoid using PASS action block in SVA
@@ -65,50 +39,32 @@ PySlint: Violation: [SVA_NO_PASS_AB]: Avoid using PASS Action block - likely to 
       $info ("Pass Action Block");
     end : pass_ab
    else $error ("Fail AB");
-Following line has a trailing whitespace
-Line 2: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 PySlint: Violation: [FILE_NAME_CHECK_MODULE]: Improper File name :../sv_tests/test_sv_naming_14_p.sv Expected File name af_ sva_m.sv
-Following line has a trailing whitespace
-Line 2: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 PySlint: Violation: [FILE_NAME_CHECK_MODULE]: Improper File name :../sv_tests/test_sv_naming_15_f.sv Expected File name af_ sva_m.sv
 PySlint: Violation: [NAME_PROP_PREFIX]: Improper naming of property: bad_name: expected prefix: p_
-Following line has a trailing whitespace
-Line 2: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 Following line has a trailing whitespace
 Line 16:   endproperty
 PySlint: Violation: [FILE_NAME_CHECK_MODULE]: Improper File name :../sv_tests/test_sv_naming_16_f.sv Expected File name af_ sva_m.sv
 PySlint: Violation: [SVA_MISSING_ENDLABEL]: Missing End Label for property: p_good_name
-Following line has a trailing whitespace
-Line 2: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 PySlint: Violation: [FILE_NAME_CHECK_MODULE]: Improper File name :../sv_tests/test_sv_naming_17_f.sv Expected File name af_ sva_m.sv
 PySlint: Violation: [NAME_PROP_PREFIX]: Improper naming of property: bad_name: expected prefix: p_
-Following line has a trailing whitespace
-Line 2: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 PySlint: Violation: [FILE_NAME_CHECK_MODULE]: Improper File name :../sv_tests/test_sv_naming_18_f.sv Expected File name af_ sva_m.sv
 PySlint: Violation: [NAME_ASM_PREFIX]: Improper naming of assume directive: wrong_label: expected prefix: m_
-Following line has a trailing whitespace
-Line 2: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 PySlint: Violation: [FILE_NAME_CHECK_MODULE]: Improper File name :../sv_tests/test_sv_naming_19_f.sv Expected File name af_ sva_m.sv
 PySlint: Violation: [NAME_COV_PREFIX]: Improper naming of cover directive: wrong_label: expected prefix: c_
-Following line has a trailing whitespace
-Line 3: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 PySlint: Violation: [FILE_NAME_CHECK_CLASS]: Improper File name : ../sv_tests/test_sv_naming_20_p.sv Expected File name af_ ex_c.sv
-Following line has a trailing whitespace
-Line 3: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 PySlint: Violation: [CL_METHOD_NOT_EXTERN]: method is not declared extern:  should_have_been_extern
 PySlint: Violation: [FILE_NAME_CHECK_CLASS]: Improper File name : ../sv_tests/test_sv_naming_21_f.sv Expected File name af_ ex_c.sv
-Following line has a trailing whitespace
-Line 3: // SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 Following line has a trailing whitespace
 Line 12: endclass
 PySlint: Violation: [CL_MISSING_ENDLABEL]: Missing End Label for class: ex_c
 PySlint: Violation: [FILE_NAME_CHECK_CLASS]: Improper File name : ../sv_tests/test_sv_naming_22_f.sv Expected File name af_ ex_c.sv
 PySlint: Violation: [FILE_NAME_CHECK_MODULE]: Improper File name :../sv_tests/test_sv_naming_23_f.sv Expected File name af_ memory.sv
 Following line has a trailing whitespace
-Line 5: endclass :add
+Line 10: endclass :add
 PySlint: Violation: [NAME_CLASS_SUFFIX]: Improper naming of identifier:  add: expected suffix: _c
 PySlint: Violation: [FILE_NAME_CHECK_CLASS]: Improper File name : ../sv_tests/test_sv_naming_24_f.sv Expected File name af_ add.sv
 Following line has a trailing whitespace
-Line 3:   bit line_with_trailing_space;
+Line 8:   bit line_with_trailing_space;
 PySlint: Violation: [NAME_CLASS_SUFFIX]: Improper naming of identifier:  trailing_whitespace: expected suffix: _c
 PySlint: Violation: [FILE_NAME_CHECK_CLASS]: Improper File name : ../sv_tests/test_sv_naming_25_f.sv Expected File name af_ trailing_whitespace.sv

--- a/py_src/pyslint.py
+++ b/py_src/pyslint.py
@@ -30,6 +30,9 @@ def pyslint_update_rule_ids():
   lv_sv_ruleid_l.append ('CL_MISSING_ENDLABEL')
   lv_sv_ruleid_l.append ('PERF_CG_TOO_MANY_CROSS')
   lv_sv_ruleid_l.append ('FUNC_CNST_MISSING_CAST')
+  lv_sv_ruleid_l.append ('FILE_NAME_CHECK_MODULE')
+  lv_sv_ruleid_l.append ('FILE_NAME_CHECK_CLASS')
+  lv_sv_ruleid_l.append ('CHECK_TRAILING_SPACE')
 
 '''
 with open("cfg.toml", mode="rb") as fp:
@@ -274,7 +277,25 @@ def chk_name_style_suffix (lv_rule_id, lv_name, lv_exp_s):
     msg += lv_exp_s
     pyslint_msg (lv_rule_id, msg)
 
+def chk_class_based_file_name (lv_rule_id, lv_name, lv_exp_p):
+  if (lv_name == inp_test_name):
+    print ('AF: Class and File names are matching: ', lv_name)
+  else:
+    msg = 'Improper File name : ' 
+    msg += inp_test_name
+    msg += ' Expected File name '
+    msg += lv_exp_p
+    pyslint_msg (lv_rule_id, msg)
 
+def chk_module_based_file_name(lv_rule_id, lv_name, lv_exp_p):
+  if (lv_name == inp_test_name):
+    print ('AF: Class and File names are matching: ', lv_name)
+  else:
+    msg = 'Improper File name :' 
+    msg += inp_test_name
+    msg += ' Expected File name '
+    msg += lv_exp_p
+    pyslint_msg (lv_rule_id, msg)
 
 def chk_naming (lv_cu_scope):
   if (lv_cu_scope.kind.name == 'ClassDeclaration'):
@@ -289,6 +310,16 @@ def chk_naming (lv_cu_scope):
 
   cg_label_chk (lv_cu_scope)
 
+def chk_file_name(lv_cu_scope):
+  if (lv_cu_scope.kind.name == 'ClassDeclaration'): 
+    lv_ident_name =str(lv_cu_scope.name)
+    lv_exp_s='af_'+lv_ident_name+'.'+'sv'
+    chk_class_based_file_name ('FILE_NAME_CHECK_CLASS', lv_ident_name, lv_exp_s)
+  else: 
+    if(lv_cu_scope.kind.name != 'FunctionDeclaration'):
+      lv_ident_name =str(lv_cu_scope.header.name)
+      lv_exp_s='af_'+lv_ident_name+'.'+'sv'
+      chk_module_based_file_name('FILE_NAME_CHECK_MODULE', lv_ident_name, lv_exp_s)
 
 args = pyslint_argparse()
 
@@ -306,12 +337,21 @@ if (tree.root.members.__str__() == ''):
   print ("PySlint: No modules/interfaces/classes found")
   exit (0)
 
+with open(inp_test_name, 'r') as file:
+    lines = file.readlines()
+
+for i, line in enumerate(lines, start=1):
+#Spliting string and white space and endswith make sure it has trailing space
+    if line.rstrip('\n').endswith(' '):
+        print("Following line has a trailing whitespace")
+        print(f"Line {i}: {line.rstrip()}")
 
 for scope_i in (tree.root.members):
   chk_naming (scope_i)
   use_extern (scope_i)
   cnst_arr_method_cast (scope_i)
   cl_endlabel_chk (scope_i)
+  chk_file_name (scope_i)
 
 
 cu_scope = tree.root.members[0]

--- a/sv_tests/test_sv_naming_01_p.sv
+++ b/sv_tests/test_sv_naming_01_p.sv
@@ -1,5 +1,5 @@
 //----------------------------------------------------
-// SPDX-FileCopyrightText: Srinivasan Venkataramanan, 
+// SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 //                         AsFigo Technologies, UK
 // SPDX-License-Identifier: MIT
 //----------------------------------------------------

--- a/sv_tests/test_sv_naming_02_f.sv
+++ b/sv_tests/test_sv_naming_02_f.sv
@@ -1,5 +1,5 @@
 //----------------------------------------------------
-// SPDX-FileCopyrightText: Srinivasan Venkataramanan, 
+// SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 //                         AsFigo Technologies, UK
 // SPDX-License-Identifier: MIT
 //----------------------------------------------------

--- a/sv_tests/test_sv_naming_03_p.sv
+++ b/sv_tests/test_sv_naming_03_p.sv
@@ -1,5 +1,5 @@
 //----------------------------------------------------
-// SPDX-FileCopyrightText: Srinivasan Venkataramanan, 
+// SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 //                         AsFigo Technologies, UK
 // SPDX-License-Identifier: MIT
 //----------------------------------------------------

--- a/sv_tests/test_sv_naming_04_f.sv
+++ b/sv_tests/test_sv_naming_04_f.sv
@@ -1,5 +1,5 @@
 //----------------------------------------------------
-// SPDX-FileCopyrightText: Srinivasan Venkataramanan, 
+// SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 //                         AsFigo Technologies, UK
 // SPDX-License-Identifier: MIT
 //----------------------------------------------------

--- a/sv_tests/test_sv_naming_05_p.sv
+++ b/sv_tests/test_sv_naming_05_p.sv
@@ -1,5 +1,5 @@
 //----------------------------------------------------
-// SPDX-FileCopyrightText: Srinivasan Venkataramanan, 
+// SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 //                         AsFigo Technologies, UK
 // SPDX-License-Identifier: MIT
 //----------------------------------------------------

--- a/sv_tests/test_sv_naming_06_f.sv
+++ b/sv_tests/test_sv_naming_06_f.sv
@@ -1,5 +1,5 @@
 //----------------------------------------------------
-// SPDX-FileCopyrightText: Srinivasan Venkataramanan, 
+// SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 //                         AsFigo Technologies, UK
 // SPDX-License-Identifier: MIT
 //----------------------------------------------------

--- a/sv_tests/test_sv_naming_07_p.sv
+++ b/sv_tests/test_sv_naming_07_p.sv
@@ -1,5 +1,5 @@
 //----------------------------------------------------
-// SPDX-FileCopyrightText: Srinivasan Venkataramanan, 
+// SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 //                         AsFigo Technologies, UK
 // SPDX-License-Identifier: MIT
 //----------------------------------------------------

--- a/sv_tests/test_sv_naming_08_f.sv
+++ b/sv_tests/test_sv_naming_08_f.sv
@@ -1,5 +1,5 @@
 //----------------------------------------------------
-// SPDX-FileCopyrightText: Srinivasan Venkataramanan, 
+// SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 //                         AsFigo Technologies, UK
 // SPDX-License-Identifier: MIT
 //----------------------------------------------------

--- a/sv_tests/test_sv_naming_09_p.sv
+++ b/sv_tests/test_sv_naming_09_p.sv
@@ -1,5 +1,5 @@
 //----------------------------------------------------
-// SPDX-FileCopyrightText: Srinivasan Venkataramanan, 
+// SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 //                         AsFigo Technologies, UK
 // SPDX-License-Identifier: MIT
 //----------------------------------------------------

--- a/sv_tests/test_sv_naming_10_f.sv
+++ b/sv_tests/test_sv_naming_10_f.sv
@@ -1,5 +1,5 @@
 //----------------------------------------------------
-// SPDX-FileCopyrightText: Srinivasan Venkataramanan, 
+// SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 //                         AsFigo Technologies, UK
 // SPDX-License-Identifier: MIT
 //----------------------------------------------------

--- a/sv_tests/test_sv_naming_11_f.sv
+++ b/sv_tests/test_sv_naming_11_f.sv
@@ -1,5 +1,5 @@
 //----------------------------------------------------
-// SPDX-FileCopyrightText: Srinivasan Venkataramanan, 
+// SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 //                         AsFigo Technologies, UK
 // SPDX-License-Identifier: MIT
 //----------------------------------------------------

--- a/sv_tests/test_sv_naming_12_f.sv
+++ b/sv_tests/test_sv_naming_12_f.sv
@@ -1,5 +1,5 @@
 //----------------------------------------------------
-// SPDX-FileCopyrightText: Srinivasan Venkataramanan, 
+// SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 //                         AsFigo Technologies, UK
 // SPDX-License-Identifier: MIT
 //----------------------------------------------------

--- a/sv_tests/test_sv_naming_13_f.sv
+++ b/sv_tests/test_sv_naming_13_f.sv
@@ -1,5 +1,5 @@
 //----------------------------------------------------
-// SPDX-FileCopyrightText: Srinivasan Venkataramanan, 
+// SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 //                         AsFigo Technologies, UK
 // SPDX-License-Identifier: MIT
 //----------------------------------------------------

--- a/sv_tests/test_sv_naming_14_p.sv
+++ b/sv_tests/test_sv_naming_14_p.sv
@@ -1,5 +1,5 @@
 //----------------------------------------------------
-// SPDX-FileCopyrightText: Srinivasan Venkataramanan, 
+// SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 //                         AsFigo Technologies, UK
 // SPDX-License-Identifier: MIT
 //----------------------------------------------------

--- a/sv_tests/test_sv_naming_15_f.sv
+++ b/sv_tests/test_sv_naming_15_f.sv
@@ -1,5 +1,5 @@
 //----------------------------------------------------
-// SPDX-FileCopyrightText: Srinivasan Venkataramanan, 
+// SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 //                         AsFigo Technologies, UK
 // SPDX-License-Identifier: MIT
 //----------------------------------------------------

--- a/sv_tests/test_sv_naming_16_f.sv
+++ b/sv_tests/test_sv_naming_16_f.sv
@@ -1,5 +1,5 @@
 //----------------------------------------------------
-// SPDX-FileCopyrightText: Srinivasan Venkataramanan, 
+// SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 //                         AsFigo Technologies, UK
 // SPDX-License-Identifier: MIT
 //----------------------------------------------------

--- a/sv_tests/test_sv_naming_17_f.sv
+++ b/sv_tests/test_sv_naming_17_f.sv
@@ -1,5 +1,5 @@
 //----------------------------------------------------
-// SPDX-FileCopyrightText: Srinivasan Venkataramanan, 
+// SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 //                         AsFigo Technologies, UK
 // SPDX-License-Identifier: MIT
 //----------------------------------------------------

--- a/sv_tests/test_sv_naming_18_f.sv
+++ b/sv_tests/test_sv_naming_18_f.sv
@@ -1,5 +1,5 @@
 //----------------------------------------------------
-// SPDX-FileCopyrightText: Srinivasan Venkataramanan, 
+// SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 //                         AsFigo Technologies, UK
 // SPDX-License-Identifier: MIT
 //----------------------------------------------------

--- a/sv_tests/test_sv_naming_19_f.sv
+++ b/sv_tests/test_sv_naming_19_f.sv
@@ -1,5 +1,5 @@
 //----------------------------------------------------
-// SPDX-FileCopyrightText: Srinivasan Venkataramanan, 
+// SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 //                         AsFigo Technologies, UK
 // SPDX-License-Identifier: MIT
 //----------------------------------------------------

--- a/sv_tests/test_sv_naming_20_p.sv
+++ b/sv_tests/test_sv_naming_20_p.sv
@@ -1,6 +1,6 @@
 //----------------------------------------------------
 //----------------------------------------------------
-// SPDX-FileCopyrightText: Srinivasan Venkataramanan, 
+// SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 //                         AsFigo Technologies, UK
 // SPDX-License-Identifier: MIT
 //----------------------------------------------------

--- a/sv_tests/test_sv_naming_21_f.sv
+++ b/sv_tests/test_sv_naming_21_f.sv
@@ -1,6 +1,6 @@
 //----------------------------------------------------
 //----------------------------------------------------
-// SPDX-FileCopyrightText: Srinivasan Venkataramanan, 
+// SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 //                         AsFigo Technologies, UK
 // SPDX-License-Identifier: MIT
 //----------------------------------------------------

--- a/sv_tests/test_sv_naming_22_f.sv
+++ b/sv_tests/test_sv_naming_22_f.sv
@@ -1,6 +1,6 @@
 //----------------------------------------------------
 //----------------------------------------------------
-// SPDX-FileCopyrightText: Srinivasan Venkataramanan, 
+// SPDX-FileCopyrightText: Srinivasan Venkataramanan,
 //                         AsFigo Technologies, UK
 // SPDX-License-Identifier: MIT
 //----------------------------------------------------

--- a/sv_tests/test_sv_naming_23_f.sv
+++ b/sv_tests/test_sv_naming_23_f.sv
@@ -1,0 +1,26 @@
+module memory(
+    address,
+    data_in,
+    data_out,
+    read_write,
+    chip_en
+  );
+
+  input wire [7:0] address, data_in;
+  output reg [7:0] data_out;
+  input wire read_write, chip_en;
+
+  reg [7:0] mem [0:255];
+
+  always @ (address or data_in or read_write or chip_en)
+    if (read_write == 1 && chip_en == 1) begin
+      mem[address] = data_in;
+  end
+
+  always @ (read_write or chip_en or address)
+    if (read_write == 0 && chip_en)
+      data_out = mem[address];
+    else
+      data_out = 0;
+
+endmodule

--- a/sv_tests/test_sv_naming_23_f.sv
+++ b/sv_tests/test_sv_naming_23_f.sv
@@ -1,3 +1,8 @@
+//----------------------------------------------------
+// SPDX-FileCopyrightText: Jayaraman R P,
+//                         Verifworks Pvt Ltd,India
+// SPDX-License-Identifier: MIT
+//----------------------------------------------------
 module memory(
     address,
     data_in,
@@ -9,18 +14,5 @@ module memory(
   input wire [7:0] address, data_in;
   output reg [7:0] data_out;
   input wire read_write, chip_en;
-
-  reg [7:0] mem [0:255];
-
-  always @ (address or data_in or read_write or chip_en)
-    if (read_write == 1 && chip_en == 1) begin
-      mem[address] = data_in;
-  end
-
-  always @ (read_write or chip_en or address)
-    if (read_write == 0 && chip_en)
-      data_out = mem[address];
-    else
-      data_out = 0;
 
 endmodule

--- a/sv_tests/test_sv_naming_24_f.sv
+++ b/sv_tests/test_sv_naming_24_f.sv
@@ -1,0 +1,5 @@
+class add;
+  bit var1;
+  bit var2;
+
+endclass :add 

--- a/sv_tests/test_sv_naming_24_f.sv
+++ b/sv_tests/test_sv_naming_24_f.sv
@@ -1,3 +1,8 @@
+//----------------------------------------------------
+// SPDX-FileCopyrightText: Jayaraman R P,
+//                         Verifworks Pvt Ltd,India
+// SPDX-License-Identifier: MIT
+//----------------------------------------------------
 class add;
   bit var1;
   bit var2;

--- a/sv_tests/test_sv_naming_25_f.sv
+++ b/sv_tests/test_sv_naming_25_f.sv
@@ -1,3 +1,8 @@
+//----------------------------------------------------
+// SPDX-FileCopyrightText: Jayaraman R P,
+//                         Verifworks Pvt Ltd,India
+// SPDX-License-Identifier: MIT
+//----------------------------------------------------
 class trailing_whitespace;
   bit line_wo_trailing_space;
   bit line_with_trailing_space; 

--- a/sv_tests/test_sv_naming_25_f.sv
+++ b/sv_tests/test_sv_naming_25_f.sv
@@ -1,0 +1,5 @@
+class trailing_whitespace;
+  bit line_wo_trailing_space;
+  bit line_with_trailing_space; 
+
+endclass: trailing_whitespace


### PR DESCRIPTION
1. checks for file name and class/module name and suggest new file name if the present file name doesn't match the standards 
2. Checks for trailing space and report the exact line which has trailing space